### PR TITLE
Update sitl_gazebo_formation.sh

### DIFF
--- a/sh/sh_for_simulation/sitl_gazebo_formation.sh
+++ b/sh/sh_for_simulation/sitl_gazebo_formation.sh
@@ -1,6 +1,6 @@
 ##sitl_gazebo
 gnome-terminal --window -e 'bash -c "roscore; exec bash"' \
---tab -e 'bash -c "sleep 2; roslaunch px4_command three_uav_mavros_sitl.launch; exec bash"' \
+--tab -e 'bash -c "sleep 5; roslaunch px4 three_uav_mavros_sitl.launch; exec bash"' \
 --tab -e 'bash -c "sleep 5; rosrun px4_command formation_control_sitl; exec bash"' \
 --tab -e 'bash -c "sleep 5; rosrun px4_command move; exec bash"' \
 


### PR DESCRIPTION
修复启动多机仿真是在本地Firmware下面的launch,并非px4_command